### PR TITLE
Converting to use NugetForUnity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
+/[Aa]ssets/[Pp]ackages/
+/[Nn]uget/
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data
@@ -148,3 +150,4 @@ CodeCoverage/
 CAPSImg.dll
 .atari800.cfg
 ProjectSettings/Packages/com.unity.testtools.codecoverage/
+Assets/Packages.meta

--- a/Assets/NuGet.config
+++ b/Assets/NuGet.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+       <clear/>
+       <add key="NuGet" value="http://www.nuget.org/api/v2/" />
+    </packageSources>
+    <disabledPackageSources />
+    <activePackageSource>
+       <add key="All" value="(Aggregate source)" />
+    </activePackageSource>
+    <config>
+       <add key="repositoryPath" value="./Packages" />
+       <add key="DefaultPushSource" value="http://www.nuget.org/api/v2/" />
+    </config>
+</configuration>

--- a/Assets/NuGet.config.meta
+++ b/Assets/NuGet.config.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 4ee5f43778d574a3cb0ce1cd0a39ded6
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <package id="Microsoft.Win32.Registry" version="6.0.0-preview.5.21301.5" targetFramework="netstandard2.0" allowedVersions="" />
+  <package id="System.Security.AccessControl" version="6.0.2-mauipre.1.22102.15" targetFramework="netstandard2.0" allowedVersions="" />
+  <package id="System.Security.Principal.Windows" version="6.0.0-preview.5.21301.5" targetFramework="netstandard2.0" allowedVersions="" />
+</packages>

--- a/Assets/packages.config.meta
+++ b/Assets/packages.config.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 02f0f1cd3aff141c7a0a25f3b824c642
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,6 +2,8 @@
   "dependencies": {
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.sk.libretro": "https://github.com/Skurdt/SK.Libretro.git",
+    "org.nuget": "https://github.com/badjano/NuGetForUnity.git",
+    "org.kumas.nuget-importer": "https://github.com/kumaS-nu/NuGet-importer-for-Unity.git?path=NuGetImporterForUnity/Packages/NuGet Importer",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ai.navigation": "1.1.1",
     "com.unity.burst": "1.7.4",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -15,6 +15,8 @@
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualeffectgraph": "14.0.4",
+    "org.kumas.nuget-importer": "https://github.com/kumaS-nu/NuGet-importer-for-Unity.git?path=NuGetImporterForUnity/Packages/NuGet Importer",
+    "org.nuget": "https://github.com/badjano/NuGetForUnity.git",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/ProjectSettings/existingPackages.xml
+++ b/ProjectSettings/existingPackages.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <package id="HtmlAgilityPack" version="0.0.0" allowedVersions="" />
+  <package id="NAudio.Core" version="0.0.0" allowedVersions="" />
+  <package id="NAudio.WinMM" version="0.0.0" allowedVersions="" />
+  <package id="Newtonsoft.Json" version="0.0.0" allowedVersions="" />
+</packages>

--- a/ProjectSettings/packageAsmNames.json
+++ b/ProjectSettings/packageAsmNames.json
@@ -1,0 +1,22 @@
+{
+    "managedList": [
+        {
+            "packageName": "Microsoft.Win32.Registry",
+            "fileNames": [
+                "Microsoft.Win32.Registry"
+            ]
+        },
+        {
+            "packageName": "System.Security.AccessControl",
+            "fileNames": [
+                "System.Security.AccessControl"
+            ]
+        },
+        {
+            "packageName": "System.Security.Principal.Windows",
+            "fileNames": [
+                "System.Security.Principal.Windows"
+            ]
+        }
+    ]
+}

--- a/ProjectSettings/rootPackages.xml
+++ b/ProjectSettings/rootPackages.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />


### PR DESCRIPTION
This change adds NuGetForUnity and NuGet Importer to manage the nuget based dependencies, adding to enable CI/CD builds, as well as making it easier to pull in other dependencies.